### PR TITLE
Chat-Space自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -44,5 +44,52 @@ $(document).on('turbolinks:load', function () {
         $('.form__submit').prop('disabled', false);　//ここで解除している
       })
   });
-})
+  var reloadMessages = function() {
+    last_message_id = $('.message:last').data('id');
+    function buildHTML(message) {
+      var body = message.content
+      var image = message.image ? `${ message.image }` : "";
+      var html =
+        `<div class="message" data-message-id=${message.id}>
+           <div class="upper-info">
+             <p class="upper-info__text">
+               ${message.user_name}
+             </p>
+             <p class="upper-info__data">
+               ${message.date}
+             </p>
+           </div>
+           <p class="message__text">
+             ${body}
+           </p>
+           <img class="lower-message__image" src=${image}>
+         </div>`
+        return html;
+    }
+
+    current_url = location.href;
+    if (current_url.match(/\/groups\/\d+\/messages/)) {
+      $.ajax({
+        url: 'api/messages',
+        type: "GET",
+        dataType: 'json',
+        data: { id: last_message_id }
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        if (messages.length !== 0) {
+          messages.forEach(function(message) {
+            insertHTML += buildHTML(message);
+            $('.messages').append(insertHTML);
+            $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+          })
+        }
+      })
+      .fail(function() {
+        alert('自動更新に失敗しました')
+      })
+    };
+  };
+  setInterval(reloadMessages, 5000);
+});
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,12 @@
+class Api::MessagesController < ApplicationController
+  before_action :set_group, only: :index
+
+  def index
+    @messages = @group.messages.where('id > ?', params[:id])
+  end
+
+  private
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+end

--- a/app/views/api/index.json.jbuilder
+++ b/app/views/api/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{ data: {id: message.id} }
   .upper-info
     %p.upper-info__text
       = message.user.name


### PR DESCRIPTION
# WHAT
メッセージの更新が自動で行われるようにした。
# WHY
手動更新では、他のユーザーが送信したメッセージを表示するために、都度ページの更新を行う必要があるため、自動でページの更新を行う機能の実装を行った。